### PR TITLE
Soporte para Docker y devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
+{
+    "name": "UTN Flowchart Devcontainer",
+    "build": {
+            "context": "..",
+            "dockerfile": "../Dockerfile",
+            "target": "dev"
+    },
+
+    "workspaceFolder": "/app",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/app,type=bind,consistency=cached",
+
+    "customizations": {
+            "vscode": {
+                    "settings": {
+                            "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+                            "editor.formatOnSave": true,
+                            "editor.codeActionsOnSave": {
+                                    "source.fixAll": true,
+                                    "source.organizeImports": true
+                            },
+                            "editor.insertSpaces": false,
+                            "eslint.enable": true,
+                            "eslint.format.enable": true,
+                            "eslint.codeActionsOnSave.mode": "all",
+                            "eslint.run": "onSave"
+                    },
+                    "extensions": [
+                            "dbaeumer.vscode-eslint"
+                    ]
+            }
+    },
+    "remoteUser": "node"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:18.16.0-slim AS base
+WORKDIR /app
+
+FROM base AS dev
+RUN apt update && \
+    apt install -y git fish vim && \
+    chsh -s /usr/bin/fish node
+
+FROM base AS build
+COPY package*.json ./
+RUN yarn install
+COPY . .
+RUN yarn build
+
+FROM nginx:stable AS deploy
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -130,3 +130,29 @@ La incorporación del plan de estudio en cuestión se verá reflejada en la apli
 <p align="center">
   <img src="https://github.com/jlsuh/utn-flowchart/assets/38252227/9329e986-0b66-4d95-bd14-9837aac545f0">
 </p>
+
+## Levantar la aplicación con Docker
+Existe la posibilidad de levantar la aplicación localmente usando docker. Para ello, se puede obtener la imagen para el contenedor de las siguientes maneras:
+### Crear la imagen a partir del repositorio
+Clonar el repositorio y posicionarse en la carpeta raiz del proyecto. Una vez hecho esto, ejecutar:
+```
+docker build -t utn-flowchart .
+```
+
+### Obteniendo la imagen desde Docker Hub
+También existe una imagen publicada en docker hub. Se puede obtener haciendo:
+```
+docker pull int0x80sys/utn-flowchart:latest
+```
+
+### Creando el contenedor
+Una vez obtenida la imagen, se puede crear el contenedor y levantar la aplicación de la siguiente manera:
+```
+docker run --rm -d -p 80:80 utn-flowchart
+```
+o en caso de haber obtenido la imagen desde el repositorio de docker hub:
+```
+docker run --rm -d -p 80:80 int0x80sys/utn-flowchart
+```
+
+La aplicación correrá en `localhost` en el puerto 80


### PR DESCRIPTION
# Descripición
Agregué un docker file y unos steps en el README sobre cómo se puede levantar la aplicación usando docker. Ademas, agregué la posibilidad de usar devcontainer, que es una forma de levantar el entorno de desarrollo desde vscode usando la extensión de devcontainer.

# Revisar
En el readme, ademas de la posibilidad de buildear la imagen desde el proyecto, agregué una segunda alternativa que es la de publicar la imagen en docker hub. Esta alternativa permite no tener que clonar el repositorio y directamente obtener la imagen para levantar la aplicación.

En el readme aparece publicado con mi user (int0x80), pero se puede usar cualquier user. Lo puse a modo de ejemplo para que se vea como quedaría. Y también tengo publicado en ese usuario la imagen a modo de prueba. Pero preferiría que sea otro usuario, como **jlsuh/utn-flowchart** en vez del mio. Una vez que esté publicado, modifico el readme y elimino mi imagen de mi docker hub
